### PR TITLE
changed properties for overflow description

### DIFF
--- a/src/css/unique-components.css
+++ b/src/css/unique-components.css
@@ -79,7 +79,7 @@ text-transform: uppercase;
 }
 .comp-overlay-title{
     color:var(--black);
-    margin-bottom: 8px;
+    margin-bottom: 12px;
     text-transform: uppercase;
 }
 .comp-overlay-ingredient{
@@ -109,8 +109,9 @@ text-transform: uppercase;
 }
 .comp-overlay-description{
     color: var(--black);
+    width: auto;
     height: 146px;
-    overflow:scroll;
+    overflow-y:auto;
 }
 
 .comp-overlay{


### PR DESCRIPTION
Змінив значення для  com-overflow-description. виправив помилку зі скролом. Також задав значення марджину відмінне від значення в макеті для .comp-overlay-title, 12px замість 8px. Значно краще візуальне відображення.